### PR TITLE
Fix Breaking Changes Due to Changes in the Mensa Website

### DIFF
--- a/stw_potsdam/xml_types/meal_xml.py
+++ b/stw_potsdam/xml_types/meal_xml.py
@@ -40,7 +40,10 @@ class MealXML:
                 continue
             price = doc.createElement("price")
             price.setAttribute("role", key)
-            txt_node = doc.createTextNode(f"{val:.2f}")
+            try:
+                txt_node = doc.createTextNode(f"{val:.2f}")
+            except Exception:
+                txt_node = doc.createTextNode("0.00")
             price.appendChild(txt_node)
             meal.appendChild(price)
         return meal

--- a/stw_potsdam/xml_types/times_xml.py
+++ b/stw_potsdam/xml_types/times_xml.py
@@ -76,9 +76,10 @@ class TimesXML:
             else:
                 raise KeyError()
 
-    def __create_node(
-        self, doc: minidom.Document, tag: str, value: CanteenOpenTimespec
-    ):
+    def __create_node(self,
+                      doc: minidom.Document,
+                      tag: str,
+                      value: CanteenOpenTimespec):
         elem = doc.createElement(tag)
         if value in CanteenOpenTimespec.CLOSED_VALID_VALUES:
             elem.setAttribute("closed", "true")

--- a/stw_potsdam/xml_types/times_xml.py
+++ b/stw_potsdam/xml_types/times_xml.py
@@ -15,8 +15,9 @@ class CanteenOpenTimespec(str):
         "",
     }
 
-    PATTERN = (r'.*(?P<hour1>\d{1,2}):(?P<min1>\d{1,2})\s*'
-               r'-\s*(?P<hour2>\d{1,2}):(?P<min2>\d{1,2}).*')
+    PATTERN = (r'.*(?P<hour1>\d{1,2}):(?P<min1>\d{1,2})'
+               r'\D*(?P<hour2>\d{1,2}):(?P<min2>\d{1,2}).*')
+    
     MATCHER = re.compile(PATTERN)
 
     def __new__(cls, spec):
@@ -75,10 +76,9 @@ class TimesXML:
             else:
                 raise KeyError()
 
-    def __create_node(self,
-                      doc: minidom.Document,
-                      tag: str,
-                      value: CanteenOpenTimespec):
+    def __create_node(
+        self, doc: minidom.Document, tag: str, value: CanteenOpenTimespec
+    ):
         elem = doc.createElement(tag)
         if value in CanteenOpenTimespec.CLOSED_VALID_VALUES:
             elem.setAttribute("closed", "true")


### PR DESCRIPTION
After some recent changes to the Mensa website, the parser seems to be broken (returning an internal server error). This PR provides a quick fix by proposing two changes:

1. It seems like they changed the hyphen in the opening time string with an "Em Dash" (—) which breaks the whole parser. I modified the regex to match all characters between the opening and closing time to make it more robust.

2. Also, it seems like `None` is returned for some price values which currently also breaks the whole parser. I added a catch for this exception which sets a price of "0.00". This is not perfect but at least it does not make the whole parser crash. If someone has time to further investigate and improve the parsing, this would be very welcome for a future PR  I guess.